### PR TITLE
Cityscope precreate volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /srv/
 ADD . /srv/jupyterhub
 WORKDIR /srv/jupyterhub/
 
-RUN python setup.py js && pip install . && \
+RUN python setup.py js && pip install -r requirements.txt && pip install . && \
     rm -rf node_modules ~/.cache ~/.npm
 
 WORKDIR /srv/jupyterhub/

--- a/jupyterhub/cityscope_spawner.py
+++ b/jupyterhub/cityscope_spawner.py
@@ -1,0 +1,82 @@
+from dockerspawner import DockerSpawner
+from tornado import gen
+
+class CityscopeSpawner(DockerSpawner):
+
+    @gen.coroutine
+    def start(self, image=None, extra_create_kwargs=None,
+        extra_start_kwargs=None, extra_host_config=None):
+        """Start the single-user server in a docker container. You can override
+        the default parameters passed to `create_container` through the
+        `extra_create_kwargs` dictionary and passed to `start` through the
+        `extra_start_kwargs` dictionary.  You can also override the
+        'host_config' parameter passed to `create_container` through the
+        `extra_host_config` dictionary.
+        Per-instance `extra_create_kwargs`, `extra_start_kwargs`, and
+        `extra_host_config` take precedence over their global counterparts.
+        """
+        container = yield self.get_container()
+        if container is None:
+            image = image or self.container_image
+
+            # build the dictionary of keyword arguments for create_container
+            create_kwargs = dict(
+                image=image,
+                environment=self.get_env(),
+                volumes=self.volume_mount_points,
+                name=self.container_name)
+            create_kwargs.update(self.extra_create_kwargs)
+            if extra_create_kwargs:
+                create_kwargs.update(extra_create_kwargs)
+
+            # build the dictionary of keyword arguments for host_config
+            host_config = dict(binds=self.volume_binds, links=self.links)
+
+            if not self.use_internal_ip:
+                host_config['port_bindings'] = {self.container_port: (self.container_ip,)}
+
+            host_config.update(self.extra_host_config)
+
+            if extra_host_config:
+                host_config.update(extra_host_config)
+
+            self.log.debug("Starting host with config: %s", host_config)
+
+            for volume in self.volume_binds.keys():
+                yield self.docker('create_volume', name=volume, driver='convoy')
+
+            host_config = self.client.create_host_config(**host_config)
+            create_kwargs.setdefault('host_config', {}).update(host_config)
+
+            # create the container
+            resp = yield self.docker('create_container', **create_kwargs)
+            self.container_id = resp['Id']
+            self.log.info(
+                "Created container '%s' (id: %s) from image %s",
+                self.container_name, self.container_id[:7], image)
+
+        else:
+            self.log.info(
+                "Found existing container '%s' (id: %s)",
+                self.container_name, self.container_id[:7])
+
+        # TODO: handle unpause
+        self.log.info(
+            "Starting container '%s' (id: %s)",
+            self.container_name, self.container_id[:7])
+
+        # build the dictionary of keyword arguments for start
+        start_kwargs = {}
+        start_kwargs.update(self.extra_start_kwargs)
+        if extra_start_kwargs:
+            start_kwargs.update(extra_start_kwargs)
+
+        # start the container
+        yield self.docker('start', self.container_id, **start_kwargs)
+
+        ip, port = yield self.get_ip_and_port()
+        # store on user for pre-jupyterhub-0.7:
+        self.user.server.ip = ip
+        self.user.server.port = port
+        # jupyterhub 0.7 prefers returning ip, port:
+        return (ip, port)

--- a/jupyterhub/data_api_spawner.py
+++ b/jupyterhub/data_api_spawner.py
@@ -930,6 +930,8 @@ class DockerProcessSpawner(DataApiSpawner):
             host_config = self.client.create_host_config(**host_config)
             create_kwargs.setdefault('host_config', {}).update(host_config)
 
+            for volume in self.volume_binds.keys():
+                yield self.docker('create_volume', name=volume, driver='convoy')
 
             # create the container
             resp = yield self.docker('create_container', **create_kwargs)

--- a/jupyterhub/mysql_spawner.py
+++ b/jupyterhub/mysql_spawner.py
@@ -646,6 +646,9 @@ class MySQLProcessSpawner(MySQLSpawner):
 
             self.log.debug("Starting MySQL host with config: %s", host_config)
 
+            for volume in self.volume_binds.keys():
+                yield self.docker('create_volume', name=volume, driver='convoy')
+
             host_config = self.client.create_host_config(**host_config)
             create_kwargs.setdefault('host_config', {}).update(host_config)
 

--- a/jupyterhub/wordpress_spawner.py
+++ b/jupyterhub/wordpress_spawner.py
@@ -659,6 +659,9 @@ class WordpressProcessSpawner(WordpressSpawner):
 
             self.log.debug("Starting Wordpress host with config: %s", host_config)
 
+            for volume in self.volume_binds.keys():
+                yield self.docker('create_volume', name=volume, driver='convoy')
+
             host_config = self.client.create_host_config(**host_config)
             create_kwargs.setdefault('host_config', {}).update(host_config)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ requests
 escapism
 docker-py
 PyGithub
+git+https://github.com/cwaldbieser/jhub_remote_user_authenticator.git#egg=remote-user
+git+https://github.com/jupyterhub/dockerspawner.git#egg=dockerspawner


### PR DESCRIPTION
The first commit here is because a container built from this Dockerfile didn't actually run, because it didn't have all the dependencies. I wonder if the container that is running in service is actually based off of https://gitlab.edina.ac.uk/cityscope/cityscope-jupyterhub/blob/master/Dockerfile, but I'm not sure there's really any need for having separate ones.

The second commit adds the commands to create the volumes before the containers starts. It's pretty clunky, and I've just over-ridden the whole method from DockerSpawner, and copied the change across all our spawners, although I do still think in future it would be good to have all our spawners inherit from a common parent.

Note that this required a changed to the config to use our spawner rather than the base DockerSpawner, so you may wish to have a look at https://gitlab.edina.ac.uk/cityscope/cityscope-infrastructure/compare/master...precreate_volumes (which is still work-in-progress), in particular, https://gitlab.edina.ac.uk/cityscope/cityscope-infrastructure/compare/master...precreate_volumes#ffebf56e68f2f35bc5b311cdd7693c5efb1b0d39_0_18